### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
   
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
   
 branding:


### PR DESCRIPTION
Update to node16 based on the warning being annotated in the summary of my [project](https://github.com/JsonMapper/JsonMapper/actions/runs/5219089171). The follows the outline from https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ and https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions